### PR TITLE
Adds support to links containing inline content.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@ const visit = require("unist-util-visit");
 const defaults = require("./defaults");
 const isLocalLink = require("./is-local-link");
 const mergeObjects = require("./merge-objects");
+const linkInnerText = require("./link-inner-text");
 
 const tagAnchorWithClassName = (node, options) => {
   const { url, title, children } = node;
 
-  const innerText = children.length > 0 ? children[0].value : "";
+  const innerText = linkInnerText(node);
   const titleAttribute = !!title ? title : innerText;
 
   const shouldAddTargetAndRel = !isLocalLink(url, options.localLinkMatch);

--- a/link-inner-text.js
+++ b/link-inner-text.js
@@ -1,0 +1,15 @@
+const innerText = function(node) {
+  return (
+    (node &&
+      (node.value ||
+        ("children" in node &&
+          node.children.map(
+            innerText
+          ).join("")
+        )
+      )
+    ) || ""
+  )
+};
+
+module.exports = innerText;

--- a/tests/link-inner-text.test.js
+++ b/tests/link-inner-text.test.js
@@ -1,0 +1,19 @@
+const linkInnerText = require("../link-inner-text");
+
+// [link *foo **bar** `#`*](/uri)
+test("it should flatten link content as text", () => {
+  const node = { type: 'link',
+    title: null,
+    url: '/uri',
+    children: [
+      { type: 'text', value: 'link *foo ' },
+      { type: 'strong', children: [{ type: 'text', value: 'bar'}] },
+      { type: 'text', value: ' ' },
+      { type: 'inlineCode', value: '#' },
+      { type: 'text', value: '*' }
+    ],
+  };
+  expect(linkInnerText(node)).toEqual(
+    "link *foo bar #*"
+  );
+});

--- a/tests/remark-plugin.test.js
+++ b/tests/remark-plugin.test.js
@@ -52,3 +52,20 @@ test("it should use fallback title if title is not present", () => {
     `<a class="siteLink" href="/foo" title="baz">baz</a>`
   );
 });
+
+// [**baz**](/foo)
+test("it should transform links properly from markdown containing inline content in link text", () => {
+  const markdownAST = {
+    type: "link",
+    title: null,
+    url: "/foo",
+    children: [{
+      type: "strong",
+      children: [{ type: "text", value: "baz" }]
+    }]
+  };
+  const parsedMarkdown = remarkPlugin({ markdownAST }, defaults);
+  expect(parsedMarkdown.value).toEqual(
+    `<a class="siteLink" href="/foo" title="baz">baz</a>`
+  );
+});


### PR DESCRIPTION
The approach to fix #3 is to iterate the link node's children and flatten out a "inner text" to use as link content value.
